### PR TITLE
`fern release` no longer supported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
           FERN_NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
           FERN_MAVEN_USERNAME: ${{ secrets.FERN_MAVEN_USERNAME }}
           FERN_MAVEN_TOKEN: ${{ secrets.FERN_MAVEN_TOKEN }}
-        run: fern release ${{ github.ref_name }} --log-level debug
+        run: fern generate --group external --version ${{ github.ref_name }} --log-level debug


### PR DESCRIPTION
`fern release` no longer exists and instead we should use `fern generate --group <group> --version <version>`