### PR TITLE
Update typescript generator to 0.0.241

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -2,7 +2,7 @@ groups:
   external:
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: 0.0.229
+        version: 0.0.241
         output:
           location: npm
           package-name: '@fern-api/flipt'


### PR DESCRIPTION
This PR applies the fix for https://github.com/fern-api/fern-typescript/issues/184