### PR TITLE
fix: remove commons.Pageable for now as mintlify doesnt support inheritance

### DIFF
--- a/fern/api/definition/auth.yml
+++ b/fern/api/definition/auth.yml
@@ -1,8 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
 
-imports:
-  commons: commons.yml
-
 services:
   http:
     Authentication:

--- a/fern/api/definition/flags.yml
+++ b/fern/api/definition/flags.yml
@@ -1,7 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
 
 imports:
-  commons: commons.yml
   variants: variants.yml
 
 services:
@@ -48,9 +47,10 @@ services:
 
 types:
   flagList:
-    extends: commons.Pageable
     properties:
       flags: list<flag>
+      nextPageToken: string
+      totalCount: integer
 
   flag:
     properties:

--- a/fern/api/definition/segments.yml
+++ b/fern/api/definition/segments.yml
@@ -1,7 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
 
 imports:
-  commons: commons.yml
   constraints: constraints.yml
 
 services:
@@ -48,9 +47,10 @@ services:
 
 types:
   segmentList:
-    extends: commons.Pageable
     properties:
       segments: list<segment>
+      nextPageToken: string
+      totalCount: integer
 
   segment:
     properties:


### PR DESCRIPTION
Adds 

```
nextPageToken: string
totalCount: integer
```

To all 'list' response endpoints manually instead of depending on openapi [inheritance](https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/) (`allOf`) which isn't yet supported by Mintlify, although they are aware and prioritizing it