### PR TITLE
upgrade java sdk generator to `0.0.130`

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -10,7 +10,7 @@ groups:
         github:
           repository: flipt-io/flipt-node
       - name: fernapi/fern-java-sdk
-        version: 0.0.125
+        version: 0.0.130
         github:
           repository: flipt-io/flipt-java
       - name: fernapi/fern-openapi


### PR DESCRIPTION
Upgrading to 0.0.130 will fix the java sdk generator failing on main. The new release fixes this issue https://github.com/fern-api/fern-java/issues/215. 

