### PR TITLE
fix(api/auth): add missing authentication key to create token response

### DIFF
--- a/fern/api/definition/auth.yml
+++ b/fern/api/definition/auth.yml
@@ -18,12 +18,6 @@ services:
             id: string
           response: authentication
 
-        createToken:
-          path: /method/token
-          method: POST
-          request: authenticationTokenCreateRequest
-          response: authenticationToken
-
         deleteToken:
           path: /tokens/{id}
           method: DELETE
@@ -34,6 +28,12 @@ services:
           path: /self
           method: GET
           response: authentication
+
+        createToken:
+          path: /method/token
+          method: POST
+          request: authenticationTokenCreateRequest
+          response: authenticationToken
 
 types:
   authenticationMethod:
@@ -49,7 +49,7 @@ types:
       createdAt: datetime
       updatedAt: datetime
       expiresAt: optional<datetime>
-      metadata: map<string,string>
+      metadata: map<string, string>
 
   authenticationList:
     properties:
@@ -65,3 +65,4 @@ types:
   authenticationToken:
     properties:
       clientToken: string
+      authentication: authentication


### PR DESCRIPTION
This adds the missing authentication object to the create token response.

I also did a little re-arranging of the definitions. Just because the `/auth/v1/method` prefix is going to grow with additional methods. I popped it at the bottom of the list. For organizational purposes.

I was curious about the `metadata` key in authentication, as our docs are currently describing it as the string `"object"`.
Which is wrong. I wonder if this is either (a) a bug in openapi spec output or (b) bug in wider support for `map` type in fern.

I will investigate further. But that is why I was messaging around with spacing in the `metadata` type definition.

Update: OpenAPI def looks good. Starting to think it is mintlify:
https://github.com/flipt-io/flipt-openapi/blob/main/openapi.yml#L747-L750