### PR TITLE
chore: enforce conventional commits via CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,10 @@ jobs:
 
       - name: Check Fern API is valid
         run: fern check
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Lint Commit Messages
+        uses: wagoid/commitlint-github-action@v5


### PR DESCRIPTION
uses https://github.com/wagoid/commitlint-github-action to enforce conventional commits