### PR TITLE
Add FERN_TOKEN to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,5 @@ jobs:
           FERN_NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
           FERN_MAVEN_USERNAME: ${{ secrets.FERN_MAVEN_USERNAME }}
           FERN_MAVEN_TOKEN: ${{ secrets.FERN_MAVEN_TOKEN }}
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         run: fern generate --group external --version ${{ github.ref_name }} --log-level debug


### PR DESCRIPTION
This PR adds `FERN_TOKEN` to the workflow that runs `fern generate`. In future versions of fern, this token will be required for `generate`.

**Action required:** Please add the `FERN_TOKEN` to your Github secrets so this comes through! Reach out if you don't have a token saved and we can generate a new one for you.