### PR TITLE
Add python SDK

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -18,6 +18,14 @@ groups:
           password: ${FERN_MAVEN_TOKEN}
         github:
           repository: flipt-io/flipt-java
+      - name: fernapi/fern-python-sdk
+        version: 0.1.0
+        output:
+          location: pypi
+          package-name: flipt
+          token: ${PYPI_TOKEN}
+        github:
+          repository: flipt-io/flipt-python
       - name: fernapi/fern-openapi
         version: 0.0.11-4-g1c29f6c
         github:

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "flipt",
-  "version": "0.4.23"
+  "version": "0.6.1"
 }


### PR DESCRIPTION
Here is a PR adding the Python SDK to Fern

## Steps required

1. Create a new repo called `flipt-python`
2. Give the [fern bot](https://github.com/apps/fern-api/installations/new) access to that new repo
3. Create an account on [pypi](https://pypi.org/) if you don't already have one
4. Create an API token and add it to this repo's secret with the name `PYPI_TOKEN`
5. Merge + release