### PR TITLE
upgrade java sdk generator to `0.1.0`

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -10,7 +10,7 @@ groups:
         github:
           repository: flipt-io/flipt-node
       - name: fernapi/fern-java-sdk
-        version: 0.0.130
+        version: 0.1.0
         output:
           location: maven
           coordinate: io.flipt:flipt-java

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "flipt",
-  "version": "0.6.1"
+  "version": "0.6.7"
 }


### PR DESCRIPTION
We released a new version of the Java SDK generator that has  a couple of improvements:
- Uses OkHTTP which makes the SDK android compatible
- Numerous bug fixes 