### PR TITLE
chore: upgrade java generator to `0.2.0`

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -10,7 +10,7 @@ groups:
         github:
           repository: flipt-io/flipt-node
       - name: fernapi/fern-java-sdk
-        version: 0.1.1
+        version: 0.2.0
         output:
           location: maven
           coordinate: io.flipt:flipt-java


### PR DESCRIPTION
Previously the `auth`, `auth-method-oidc` and `auth-method-k8s` were colliding. This is fixed in `0.2.0`, see [release notes ](https://github.com/fern-api/fern-java/releases)for more info. 