### PR TITLE
chore: allow for generating sdks locally / dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Tagging a release on this repository will update the:
 
 - [TypeScript SDK repo](https://github.com/flipt-io/flipt-node)
 - [Java SDK repo](https://github.com/flipt-io/flipt-java)
+- [Python SDK repo](https://github.com/flipt-io/flipt-python)
 - [OpenAPI description repo](https://github.com/flipt-io/flipt-openapi)
 - _More SDKs to come..._
 
@@ -14,7 +15,7 @@ This repository contains
 - Flipt's Fern API Definition which lives in the [definition](./fern/api/definition/) folder
 - Generators (see [generators.yml](./fern/api/generators.yml))
 
-## What is in the API Definition?
+## API Definition
 
 The API Definition contains information about what endpoints, types, and errors are used in the API. The definition is broken into smaller files such as [rules.yml](fern/api/definition/rules.yml) and [flags.yml](fern/api/definition/flags.yml).
 
@@ -25,7 +26,7 @@ npm install -g fern-api # Installs CLI
 fern check # Checks if the definition is valid
 ```
 
-## What are Generators?
+## Generators
 
 Generators read in your API Definition and output files or code (i.e. the TypeScript SDK Generator) and are tracked in [generators.yml](./fern/api/generators.yml).
 
@@ -36,3 +37,13 @@ fern generate --group external --version <version>
 ```
 
 This command currently runs in a GitHub workflow (see [ci.yml](.github/workflows/ci.yml#L32))
+
+## Development
+
+To generate the SDKs during development and confirm that they output the expected code, run:
+
+```bash
+fern generate --group development
+```
+
+This will generate the SDK code to the `/tmp/fern/flipt-{sdk}` directories where you can inspect the output.

--- a/fern/api/definition/constraints.yml
+++ b/fern/api/definition/constraints.yml
@@ -5,6 +5,7 @@ service:
   auth: true
   path-parameters:
     namespaceKey: string
+
     segmentKey: string
   endpoints:
     create:

--- a/fern/api/definition/distributions.yml
+++ b/fern/api/definition/distributions.yml
@@ -5,6 +5,7 @@ service:
   auth: true
   path-parameters:
     namespaceKey: string
+
     flagKey: string
 
     ruleId: string

--- a/fern/api/definition/rules.yml
+++ b/fern/api/definition/rules.yml
@@ -8,6 +8,7 @@ service:
   auth: true
   path-parameters:
     namespaceKey: string
+
     flagKey: string
   endpoints:
     list:

--- a/fern/api/definition/variants.yml
+++ b/fern/api/definition/variants.yml
@@ -5,6 +5,7 @@ service:
   auth: true
   path-parameters:
     namespaceKey: string
+
     flagKey: string
   endpoints:
     create:

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -1,4 +1,30 @@
 groups:
+  development:
+    generators:
+      - name: fernapi/fern-typescript-sdk
+        version: 0.1.7
+        output:
+          location: local-file-system
+          path: /tmp/fern/flipt-node
+
+      - name: fernapi/fern-java-sdk
+        version: 0.2.0
+        output:
+          location: local-file-system
+          path: /tmp/fern/flipt-java
+
+      - name: fernapi/fern-python-sdk
+        version: 0.1.4
+        output:
+          location: local-file-system
+          path: /tmp/fern/flipt-python
+
+      - name: fernapi/fern-openapi
+        version: 0.0.11-4-g1c29f6c
+        output:
+          location: local-file-system
+          path: /tmp/fern/flipt-openapi
+
   external:
     generators:
       - name: fernapi/fern-typescript-sdk
@@ -9,6 +35,7 @@ groups:
           token: ${FERN_NPM_TOKEN}
         github:
           repository: flipt-io/flipt-node
+
       - name: fernapi/fern-java-sdk
         version: 0.2.0
         output:
@@ -18,6 +45,7 @@ groups:
           password: ${FERN_MAVEN_TOKEN}
         github:
           repository: flipt-io/flipt-java
+
       - name: fernapi/fern-python-sdk
         version: 0.1.4
         output:
@@ -26,6 +54,7 @@ groups:
           token: ${FERN_PYPI_TOKEN}
         github:
           repository: flipt-io/flipt-python
+
       - name: fernapi/fern-openapi
         version: 0.0.11-4-g1c29f6c
         github:


### PR DESCRIPTION
`$ fern generate --group development`

For some reason the Java SDK does not support/allow for local file 'download'. It gives me the error:

```
ERROR 2023-04-12T16:25:31.772Z [api]: fernapi/fern-java-sdk Download files mode is unsupported!
DEBUG 2023-04-12T16:25:31.772Z [api]: fernapi/fern-java-sdk Error
                                                                at logErrorMessage (/Users/markphelps/.asdf/installs/nodejs/16.17.0/lib/node_modules/fern-api/bundle.cjs:505428:56)
                                                                at InteractiveTaskContextImpl.failWithoutThrowing (/Users/markphelps/.asdf/installs/nodejs/16.17.0/lib/node_modules/fern-api/bundle.cjs:505487:5)
                                                                at InteractiveTaskContextImpl.failAndThrow (/Users/markphelps/.asdf/installs/nodejs/16.17.0/lib/node_modules/fern-api/bundle.cjs:505482:10)
                                                                at Object.failed (/Users/markphelps/.asdf/installs/nodejs/16.17.0/lib/node_modules/fern-api/bundle.cjs:519733:22)
                                                                at Object._visit (/Users/markphelps/.asdf/installs/nodejs/16.17.0/lib/node_modules/fern-api/bundle.cjs:18133:28)
                                                                at Object.<anonymous> (/Users/markphelps/.asdf/installs/nodejs/16.17.0/lib/node_modules/fern-api/bundle.cjs:18108:53)
                                                                at RemoteTaskHandler.processUpdate (/Users/markphelps/.asdf/installs/nodejs/16.17.0/lib/node_modules/fern-api/bundle.cjs:519726:29)
                                                                at Timeout.pollForStatus [as _onTimeout] (/Users/markphelps/.asdf/installs/nodejs/16.17.0/lib/node_modules/fern-api/bundle.cjs:519653:29)
                                                                at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

/cc @dsinghvi 

```
/tmp/fern

ls -la
drwxr-xr-x   5 markphelps  wheel  160 Apr 12 12:27 .
drwxrwxrwt  10 root        wheel  320 Apr 12 12:28 ..
drwxr-xr-x  12 markphelps  wheel  384 Apr 12 12:27 flipt-node
drwxr-xr-x   3 markphelps  wheel   96 Apr 12 12:27 flipt-openapi
drwxr-xr-x   7 markphelps  wheel  224 Apr 12 12:27 flipt-python
```