### PR TITLE
Publish to draft SDK repos on every push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,20 @@ jobs:
 
       - name: Lint Commit Messages
         uses: wagoid/commitlint-github-action@v5
+
+  fern-deploy-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Fern
+        run: npm install -g fern-api
+
+      - name: Publish SDKs to draft repos
+        env:
+          FERN_PYPI_TOKEN: ${{ secrets.FERN_PYPI_TOKEN}}
+          FERN_NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
+          FERN_MAVEN_USERNAME: ${{ secrets.FERN_MAVEN_USERNAME }}
+          FERN_MAVEN_TOKEN: ${{ secrets.FERN_MAVEN_TOKEN }}
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        run: fern generate --group draft --version 0.0.0 --log-level debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,4 @@ jobs:
           FERN_MAVEN_USERNAME: ${{ secrets.FERN_MAVEN_USERNAME }}
           FERN_MAVEN_TOKEN: ${{ secrets.FERN_MAVEN_TOKEN }}
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-        run: fern generate --group external --version ${{ github.ref_name }} --log-level debug
+        run: fern generate --group release --version ${{ github.ref_name }} --log-level debug

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -1,11 +1,26 @@
 groups:
-  external:
+  draft:
+    generators:
+      - name: fernapi/fern-typescript-sdk
+        version: 0.1.7
+        github:
+          repository: flipt-io/flipt-node-draft
+      - name: fernapi/fern-java-sdk
+        version: 0.2.0
+        github:
+          repository: flipt-io/flipt-java-draft
+      - name: fernapi/fern-python-sdk
+        version: 0.1.4
+        github:
+          repository: flipt-io/flipt-python-draft
+
+  release:
     generators:
       - name: fernapi/fern-typescript-sdk
         version: 0.1.7
         output:
           location: npm
-          package-name: '@flipt-io/flipt'
+          package-name: "@flipt-io/flipt"
           token: ${FERN_NPM_TOKEN}
         github:
           repository: flipt-io/flipt-node


### PR DESCRIPTION
This PR adds a `draft` group to `generators.yml`, which publishes the SDKs to draft repos:
  - flipt-io/flipt-node-draft
  - flipt-io/flipt-java-draft
  - flipt-io/flipt-python-draft

I updated the `push` github workflow to run `fern generate --group draft`.

Action items:
1. Create the draft repos
    - flipt-io/flipt-node-draft
    - flipt-io/flipt-java-draft
    - flipt-io/flipt-python-draft
1. Add the fern bot to these 3 repos https://github.com/apps/fern-api/installations/new