### PR TITLE
fix: bump java generator to fix GET requests

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -10,7 +10,7 @@ groups:
         github:
           repository: flipt-io/flipt-node
       - name: fernapi/fern-java-sdk
-        version: 0.2.0
+        version: 0.2.1-rc0
         output:
           location: maven
           coordinate: io.flipt:flipt-java


### PR DESCRIPTION
https://github.com/fern-api/fern-java/releases/tag/0.2.1-rc0

Should fix https://github.com/flipt-io/flipt-java/issues/4