### PR TITLE
fix(api): use correct field responses in batch evaluation response

### DIFF
--- a/fern/api/definition/evaluate.yml
+++ b/fern/api/definition/evaluate.yml
@@ -57,5 +57,5 @@ types:
   batchEvaluationResponse:
     properties:
       requestId: string
-      response: list<evaluationResponse>
+      responses: list<evaluationResponse>
       requestDurationMillis: double


### PR DESCRIPTION
Fixes #65 

This corrects the field name in the response to be `responses`.