### PR TITLE
Upgrade fern to 0.8.8, ts generator to 0.5.18

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -28,7 +28,7 @@ groups:
   external:
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: 0.1.7
+        version: 0.5.18
         output:
           location: npm
           package-name: '@flipt-io/flipt'

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -2,7 +2,7 @@ groups:
   development:
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: 0.1.7
+        version: 0.5.18
         output:
           location: local-file-system
           path: /tmp/fern/flipt-node

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "flipt",
-  "version": "0.6.10"
+  "version": "0.8.8"
 }


### PR DESCRIPTION
This resolves an issue where the node sdk paths are generated with a trailing slash