### PR TITLE
fix: bump typescript generator to fix trailing slash issue

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -2,7 +2,7 @@ groups:
   development:
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: 0.1.7
+        version: 0.2.2
         output:
           location: local-file-system
           path: /tmp/fern/flipt-node
@@ -28,10 +28,10 @@ groups:
   external:
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: 0.1.7
+        version: 0.2.2
         output:
           location: npm
-          package-name: '@flipt-io/flipt'
+          package-name: "@flipt-io/flipt"
           token: ${FERN_NPM_TOKEN}
         github:
           repository: flipt-io/flipt-node

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "flipt",
-  "version": "0.6.10"
+  "version": "0.8.10"
 }


### PR DESCRIPTION
Re: https://github.com/flipt-io/flipt-api/pull/69#discussion_r1185583457

This bumps the typescript generator to a [version](https://github.com/fern-api/fern-typescript/releases/tag/0.2.2) closer to our current version to fix the trailing slash issue in https://github.com/flipt-io/flipt-node/issues/4

Plan is to create a patch release for the sdks first to solve the above issue, then create a new minor release after bumping all generators to their latest versions re: https://github.com/flipt-io/flipt-api/pull/69#discussion_r1185583457

cc @zachkirsch 


here is the patch generated between our current version and the `flipt-node` SDK generated with the changes from this PR:

```diff
diff -r ./api/resources/constraints/client/Client.js ../flipt-node/api/resources/constraints/client/Client.js
45c45
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/segments/${segmentKey}/constraints/`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/segments/${segmentKey}/constraints`),
79c79
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/segments/${segmentKey}/constraints//${id}`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/segments/${segmentKey}/constraints/${id}`),
110c110
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/segments/${segmentKey}/constraints//${id}`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/segments/${segmentKey}/constraints/${id}`),
diff -r ./api/resources/distributions/client/Client.js ../flipt-node/api/resources/distributions/client/Client.js
45c45
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules/${ruleId}/distributions/`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules/${ruleId}/distributions`),
82c82
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules/${ruleId}/distributions//${id}`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules/${ruleId}/distributions/${id}`),
114c114
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules/${ruleId}/distributions//${id}`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules/${ruleId}/distributions/${id}`),
diff -r ./api/resources/flags/client/Client.js ../flipt-node/api/resources/flags/client/Client.js
56c56
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags`),
90c90
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags`),
124c124
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags//${key}`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${key}`),
157c157
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags//${key}`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${key}`),
188c188
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags//${key}`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${key}`),
diff -r ./api/resources/rules/client/Client.js ../flipt-node/api/resources/rules/client/Client.js
56c56
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules/`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules`),
90c90
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules/`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules`),
124c124
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules//order`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules/order`),
156c156
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules//${id}`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules/${id}`),
189c189
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules//${id}`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules/${id}`),
220c220
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules//${id}`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/rules/${id}`),
diff -r ./api/resources/segments/client/Client.js ../flipt-node/api/resources/segments/client/Client.js
56c56
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/segments/`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/segments`),
90c90
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/segments/`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/segments`),
124c124
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/segments//${key}`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/segments/${key}`),
157c157
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/segments//${key}`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/segments/${key}`),
188c188
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/segments//${key}`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/segments/${key}`),
diff -r ./api/resources/variants/client/Client.js ../flipt-node/api/resources/variants/client/Client.js
45c45
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/variants/`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/variants`),
79c79
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/variants//${id}`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/variants/${id}`),
110c110
<             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/variants//${id}`),
---
>             url: (0, url_join_1.default)(this.options.environment ?? environments.FliptApiEnvironment.Production, `/api/v1/namespaces/${namespaceKey}/flags/${flagKey}/variants/${id}`),
Only in .: diff.patch
```