### PR TITLE
fix(java): update generator to v0.4.2-rc3

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -8,7 +8,7 @@ groups:
           path: /tmp/fern/flipt-node
 
       - name: fernapi/fern-java-sdk
-        version: 0.2.1
+        version: 0.4.2-rc3
         output:
           location: local-file-system
           path: /tmp/fern/flipt-java
@@ -37,7 +37,7 @@ groups:
           repository: flipt-io/flipt-node
 
       - name: fernapi/fern-java-sdk
-        version: 0.2.1
+        version: 0.4.2-rc3
         output:
           location: maven
           coordinate: io.flipt:flipt-java

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -35,6 +35,7 @@ groups:
           token: ${FERN_NPM_TOKEN}
         github:
           repository: flipt-io/flipt-node
+          mode: pull-request
 
       - name: fernapi/fern-java-sdk
         version: 0.4.2-rc3
@@ -45,6 +46,7 @@ groups:
           password: ${FERN_MAVEN_TOKEN}
         github:
           repository: flipt-io/flipt-java
+          mode: pull-request
 
       - name: fernapi/fern-python-sdk
         version: 0.4.0-rc0
@@ -60,3 +62,4 @@ groups:
         version: 0.0.11-4-g1c29f6c
         github:
           repository: flipt-io/flipt-openapi
+          mode: pull-request


### PR DESCRIPTION
Use the latest RC version of Fern to get a fix for the missing path segment in our Java clients.
Here is the issued raised on Ferns repo https://github.com/fern-api/fern-java/issues/306

The Fern team came and suggested this in Discord.
I ran this version of the generator and the path segment was there as expected.