### PR TITLE
fix(evaluation): use camel-case for batch response

### DIFF
--- a/fern/api/definition/evaluation/__package__.yml
+++ b/fern/api/definition/evaluation/__package__.yml
@@ -40,9 +40,9 @@ types:
   evaluationResponse:
     properties:
       type: evaluationResponseType
-      boolean_response: optional<booleanEvaluationResponse>
-      variant_response: optional<variantEvaluationResponse>
-      error_response: optional<errorEvaluationResponse>
+      booleanResponse: optional<booleanEvaluationResponse>
+      variantResponse: optional<variantEvaluationResponse>
+      errorResponse: optional<errorEvaluationResponse>
 
   errorEvaluationResponse:
     properties:


### PR DESCRIPTION
We should be using camel-casing, not snake for these fields.

Discovered by our friend on Discord: https://discord.com/channels/960634591000014878/1141369107380445307/1141369107380445307