### PR TITLE
fix: upgrade java generator for `custom-dependencies`

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "flipt",
-  "version": "0.15.0-rc16"
+  "version": "0.15.0-rc31"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -11,7 +11,7 @@ groups:
             "@datadog/browser-rum": "^4.48.1"
 
       - name: fernapi/fern-java-sdk
-        version: 0.5.4
+        version: 0.5.8-rc0
         output:
           location: local-file-system
           path: /tmp/fern/flipt-java
@@ -44,7 +44,7 @@ groups:
             "@datadog/browser-rum": "^4.48.1"
 
       - name: fernapi/fern-java-sdk
-        version: 0.5.4
+        version: 0.5.8-rc0
         output:
           location: maven
           coordinate: io.flipt:flipt-java

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -11,7 +11,7 @@ groups:
             "@datadog/browser-rum": "^4.48.1"
 
       - name: fernapi/fern-java-sdk
-        version: 0.5.8-rc0
+        version: 0.5.8
         output:
           location: local-file-system
           path: /tmp/fern/flipt-java
@@ -44,7 +44,7 @@ groups:
             "@datadog/browser-rum": "^4.48.1"
 
       - name: fernapi/fern-java-sdk
-        version: 0.5.8-rc0
+        version: 0.5.8
         output:
           location: maven
           coordinate: io.flipt:flipt-java


### PR DESCRIPTION
This PR upgrades fern cli and java sdk generator to handle custom-dependencies (previously produced an invalid build.gradle which caused the java generator to fail). 