### PR TITLE
feat: add JWT method type to enum

### DIFF
--- a/fern/definition/auth.yml
+++ b/fern/definition/auth.yml
@@ -44,6 +44,7 @@ types:
       - METHOD_TOKEN
       - METHOD_OIDC
       - METHOD_KUBERNETES
+      - METHOD_JWT
 
   authentication:
     properties:


### PR DESCRIPTION
Adds the JWT method to the enum. I don't think there is anything else to add for JWT. There are no extra endpoints added for managing them as they're decentralized creds.

I looked into extending the details on auth types in api.yml:
https://docs.buildwithfern.com/api-definition/fern-definition/api-yml-reference#authentication

Looks like we can define a custom scheme, but I'm not sure we have enough ways to express how our auth scheme changes. So it might be best to just leave it as `bearer` for now.